### PR TITLE
Even better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.gitsplit/
+Makefile.local

--- a/alt-galaxy/Makefile
+++ b/alt-galaxy/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -32,3 +34,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/alt-galaxy/manala/make/Makefile
+++ b/alt-galaxy/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/alt-galaxy/manala/make/Makefile.docker
+++ b/alt-galaxy/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/alt-galaxy/manala/make/Makefile.environment
+++ b/alt-galaxy/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/alt-galaxy/manala/make/Makefile.manala
+++ b/alt-galaxy/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -21,7 +21,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -43,3 +45,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/ansible/manala/make/Makefile
+++ b/ansible/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/ansible/manala/make/Makefile.docker
+++ b/ansible/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/ansible/manala/make/Makefile.environment
+++ b/ansible/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/ansible/manala/make/Makefile.manala
+++ b/ansible/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/backup-manager/Makefile
+++ b/backup-manager/Makefile
@@ -21,7 +21,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -43,3 +45,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/backup-manager/manala/make/Makefile
+++ b/backup-manager/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/backup-manager/manala/make/Makefile.docker
+++ b/backup-manager/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/backup-manager/manala/make/Makefile.environment
+++ b/backup-manager/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/backup-manager/manala/make/Makefile.manala
+++ b/backup-manager/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/cgroupfs-mount/Makefile
+++ b/cgroupfs-mount/Makefile
@@ -17,7 +17,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -29,3 +31,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/cgroupfs-mount/manala/make/Makefile
+++ b/cgroupfs-mount/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/cgroupfs-mount/manala/make/Makefile.docker
+++ b/cgroupfs-mount/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/cgroupfs-mount/manala/make/Makefile.environment
+++ b/cgroupfs-mount/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/cgroupfs-mount/manala/make/Makefile.manala
+++ b/cgroupfs-mount/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/gitsplit/Makefile
+++ b/gitsplit/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -41,3 +43,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/gitsplit/manala/make/Makefile
+++ b/gitsplit/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/gitsplit/manala/make/Makefile.docker
+++ b/gitsplit/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/gitsplit/manala/make/Makefile.environment
+++ b/gitsplit/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/gitsplit/manala/make/Makefile.manala
+++ b/gitsplit/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/httpie/Makefile
+++ b/httpie/Makefile
@@ -21,7 +21,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -43,3 +45,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/httpie/manala/make/Makefile
+++ b/httpie/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/httpie/manala/make/Makefile.docker
+++ b/httpie/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/httpie/manala/make/Makefile.environment
+++ b/httpie/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/httpie/manala/make/Makefile.manala
+++ b/httpie/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/hugo/Makefile
+++ b/hugo/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -32,3 +34,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+		$(call build_dist)

--- a/hugo/manala/make/Makefile
+++ b/hugo/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/hugo/manala/make/Makefile.docker
+++ b/hugo/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/hugo/manala/make/Makefile.environment
+++ b/hugo/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/hugo/manala/make/Makefile.manala
+++ b/hugo/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/keepalived/Makefile
+++ b/keepalived/Makefile
@@ -22,7 +22,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -44,3 +46,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/keepalived/manala/make/Makefile
+++ b/keepalived/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/keepalived/manala/make/Makefile.docker
+++ b/keepalived/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/keepalived/manala/make/Makefile.environment
+++ b/keepalived/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/keepalived/manala/make/Makefile.manala
+++ b/keepalived/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/mailhog/Makefile
+++ b/mailhog/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -32,3 +34,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/mailhog/manala/make/Makefile
+++ b/mailhog/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/mailhog/manala/make/Makefile.docker
+++ b/mailhog/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/mailhog/manala/make/Makefile.environment
+++ b/mailhog/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/mailhog/manala/make/Makefile.manala
+++ b/mailhog/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/mongo-express/Makefile
+++ b/mongo-express/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Node)
 ifeq ($(DEBIAN_DISTRIBUTION), wheezy)
@@ -42,3 +44,5 @@ endif
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/mongo-express/manala/make/Makefile
+++ b/mongo-express/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/mongo-express/manala/make/Makefile.docker
+++ b/mongo-express/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/mongo-express/manala/make/Makefile.environment
+++ b/mongo-express/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/mongo-express/manala/make/Makefile.manala
+++ b/mongo-express/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/ngrok/Makefile
+++ b/ngrok/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -33,3 +35,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/ngrok/manala/make/Makefile
+++ b/ngrok/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/ngrok/manala/make/Makefile.docker
+++ b/ngrok/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/ngrok/manala/make/Makefile.environment
+++ b/ngrok/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/ngrok/manala/make/Makefile.manala
+++ b/ngrok/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/oauth2-proxy/Makefile
+++ b/oauth2-proxy/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -34,3 +36,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/oauth2-proxy/manala/make/Makefile
+++ b/oauth2-proxy/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/oauth2-proxy/manala/make/Makefile.docker
+++ b/oauth2-proxy/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/oauth2-proxy/manala/make/Makefile.environment
+++ b/oauth2-proxy/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/oauth2-proxy/manala/make/Makefile.manala
+++ b/oauth2-proxy/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/opcache-dashboard/Makefile
+++ b/opcache-dashboard/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -32,3 +34,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/opcache-dashboard/manala/make/Makefile
+++ b/opcache-dashboard/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/opcache-dashboard/manala/make/Makefile.docker
+++ b/opcache-dashboard/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/opcache-dashboard/manala/make/Makefile.environment
+++ b/opcache-dashboard/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/opcache-dashboard/manala/make/Makefile.manala
+++ b/opcache-dashboard/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/pam-ssh-agent-auth/Makefile
+++ b/pam-ssh-agent-auth/Makefile
@@ -22,7 +22,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -47,3 +49,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/pam-ssh-agent-auth/manala/make/Makefile
+++ b/pam-ssh-agent-auth/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/pam-ssh-agent-auth/manala/make/Makefile.docker
+++ b/pam-ssh-agent-auth/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/pam-ssh-agent-auth/manala/make/Makefile.environment
+++ b/pam-ssh-agent-auth/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/pam-ssh-agent-auth/manala/make/Makefile.manala
+++ b/pam-ssh-agent-auth/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/phantomjs/Makefile
+++ b/phantomjs/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -40,3 +42,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/phantomjs/manala/make/Makefile
+++ b/phantomjs/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/phantomjs/manala/make/Makefile.docker
+++ b/phantomjs/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/phantomjs/manala/make/Makefile.environment
+++ b/phantomjs/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/phantomjs/manala/make/Makefile.manala
+++ b/phantomjs/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/phpmyadmin/Makefile
+++ b/phpmyadmin/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -32,3 +34,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/phpmyadmin/manala/make/Makefile
+++ b/phpmyadmin/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/phpmyadmin/manala/make/Makefile.docker
+++ b/phpmyadmin/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/phpmyadmin/manala/make/Makefile.environment
+++ b/phpmyadmin/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/phpmyadmin/manala/make/Makefile.manala
+++ b/phpmyadmin/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/phppgadmin/Makefile
+++ b/phppgadmin/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -32,3 +34,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/phppgadmin/manala/make/Makefile
+++ b/phppgadmin/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/phppgadmin/manala/make/Makefile.docker
+++ b/phppgadmin/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/phppgadmin/manala/make/Makefile.environment
+++ b/phppgadmin/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/phppgadmin/manala/make/Makefile.manala
+++ b/phppgadmin/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/phpredisadmin/Makefile
+++ b/phpredisadmin/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Composer)
 	sudo apt-get update
@@ -42,3 +44,5 @@ endif
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/phpredisadmin/manala/make/Makefile
+++ b/phpredisadmin/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/phpredisadmin/manala/make/Makefile.docker
+++ b/phpredisadmin/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/phpredisadmin/manala/make/Makefile.environment
+++ b/phpredisadmin/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/phpredisadmin/manala/make/Makefile.manala
+++ b/phpredisadmin/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/python-jinja2/Makefile
+++ b/python-jinja2/Makefile
@@ -21,7 +21,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -43,3 +45,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/python-jinja2/manala/make/Makefile
+++ b/python-jinja2/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/python-jinja2/manala/make/Makefile.docker
+++ b/python-jinja2/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/python-jinja2/manala/make/Makefile.environment
+++ b/python-jinja2/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/python-jinja2/manala/make/Makefile.manala
+++ b/python-jinja2/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/python-pathlib2/Makefile
+++ b/python-pathlib2/Makefile
@@ -21,7 +21,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -43,3 +45,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/python-pathlib2/manala/make/Makefile
+++ b/python-pathlib2/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/python-pathlib2/manala/make/Makefile.docker
+++ b/python-pathlib2/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/python-pathlib2/manala/make/Makefile.environment
+++ b/python-pathlib2/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/python-pathlib2/manala/make/Makefile.manala
+++ b/python-pathlib2/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/rtail/Makefile
+++ b/rtail/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Node)
 ifeq ($(DEBIAN_DISTRIBUTION), wheezy)
@@ -42,3 +44,5 @@ endif
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/rtail/manala/make/Makefile
+++ b/rtail/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/rtail/manala/make/Makefile.docker
+++ b/rtail/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/rtail/manala/make/Makefile.environment
+++ b/rtail/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/rtail/manala/make/Makefile.manala
+++ b/rtail/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/splitsh-lite/Makefile
+++ b/splitsh-lite/Makefile
@@ -19,9 +19,11 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build: export GOPATH = $(PACKAGE_BUILD_DIR)/go
-build-package@build: export PATH  := $(PATH):/usr/local/go/bin
-build-package@build:
+build: export GOPATH = $(PACKAGE_BUILD_DIR)/go
+build: export PATH  := $(PATH):/usr/local/go/bin
+build:
+
+	$(call build_clean)
 
 	$(call log,Go)
 	curl -L https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz \
@@ -50,3 +52,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/splitsh-lite/manala/make/Makefile
+++ b/splitsh-lite/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/splitsh-lite/manala/make/Makefile.docker
+++ b/splitsh-lite/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/splitsh-lite/manala/make/Makefile.environment
+++ b/splitsh-lite/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/splitsh-lite/manala/make/Makefile.manala
+++ b/splitsh-lite/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/supervisor/Makefile
+++ b/supervisor/Makefile
@@ -21,7 +21,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -43,3 +45,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/supervisor/manala/make/Makefile
+++ b/supervisor/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/supervisor/manala/make/Makefile.docker
+++ b/supervisor/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/supervisor/manala/make/Makefile.environment
+++ b/supervisor/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/supervisor/manala/make/Makefile.manala
+++ b/supervisor/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/thefuck/Makefile
+++ b/thefuck/Makefile
@@ -22,7 +22,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	debsnap --force --verbose --destdir $(PACKAGE_BUILD_DIR) $(PACKAGE) $(call package_debian_version)
@@ -44,3 +46,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc
+
+	$(call build_dist)

--- a/thefuck/manala/make/Makefile
+++ b/thefuck/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/thefuck/manala/make/Makefile.docker
+++ b/thefuck/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/thefuck/manala/make/Makefile.environment
+++ b/thefuck/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/thefuck/manala/make/Makefile.manala
+++ b/thefuck/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #

--- a/vault/Makefile
+++ b/vault/Makefile
@@ -19,7 +19,9 @@ include manala/make/Makefile
 # Build #
 #########
 
-build-package@build:
+build:
+
+	$(call build_clean)
 
 	$(call log,Checkout)
 	mkdir $(PACKAGE_BUILD_DIR)/$(PACKAGE)
@@ -32,3 +34,5 @@ build-package@build:
 	$(call log,Build)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& debuild -us -uc -b
+
+	$(call build_dist)

--- a/vault/manala/make/Makefile
+++ b/vault/manala/make/Makefile
@@ -14,12 +14,12 @@ PACKAGE_DIST_DIR  = $(PACKAGE_DIR)/dist
 
 DEBIAN_DISTRIBUTIONS = $(PACKAGE_DISTRIBUTIONS)
 
-%.wheezy: DEBIAN_DISTRIBUTION = wheezy
-%.jessie: DEBIAN_DISTRIBUTION = jessie
+%.wheezy:  DEBIAN_DISTRIBUTION = wheezy
+%.jessie:  DEBIAN_DISTRIBUTION = jessie
 %.stretch: DEBIAN_DISTRIBUTION = stretch
 
 export DEBFULLNAME = Manala
-export DEBEMAIL = contact@manala.io
+export DEBEMAIL    = contact@manala.io
 
 define package_debian_version
 $(if $(PACKAGE_EPOCH),$(PACKAGE_EPOCH):)$(PACKAGE_VERSION)-$(PACKAGE_REVISION)
@@ -56,41 +56,67 @@ include \
 	$(MANALA_DIR)/make/Makefile.docker \
 	$(MANALA_DIR)/make/Makefile.environment
 
--include $(MANALA_DIR)/../Makefile.local
+-include \
+	../Makefile.local \
+	Makefile.local
 
 ###############
 # Environment #
 ###############
 
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help_section,Environment)
 
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.wheezy,     Shell to environment - Wheezy)
-sh.wheezy:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.wheezy,     Shell to build environment - Wheezy)
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.jessie,     Shell to environment - Jessie)
-sh.jessie:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.jessie,     Shell to build environment - Jessie)
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,sh.stretch,    Shell to environment - Stretch)
-sh.stretch:
-	@$(MANALA_DOCKER_RUN)
+MANALA_HELP += $(call help,sh.stretch,    Shell to build environment - Stretch)
 endif
 
-sh.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+MANALA_HELP += $(call help,update-all,    Update all build environments)
 
-MANALA_HELP += $(call help,update-all,    Update all environments)
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.wheezy, Update build environment - Wheezy)
+endif
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.jessie, Update build environment - Jessie)
+endif
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+MANALA_HELP += $(call help,update.stretch,Update build environment - Jessie)
+endif
 
-update-all:
-	EXIT=0 ; $(foreach \
+MANALA_HELP += \n
+
+endif
+
+sh.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+sh.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+	@$(call docker_shell)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+update-all: @@local
+	@EXIT=0 ; $(foreach \
 		DEBIAN_DISTRIBUTION,\
 		$(DEBIAN_DISTRIBUTIONS),\
 		$(call log,Update $(DEBIAN_DISTRIBUTION)) \
@@ -98,98 +124,116 @@ update-all:
 		|| EXIT=$$? ;\
 	) exit $$EXIT
 
+update.wheezy: @@local
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.wheezy, Update environment - Wheezy)
-update.wheezy:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.jessie: @@local
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.jessie, Update environment - Jessie)
-update.jessie:
-	@$(MANALA_DOCKER_PULL)
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
+update.stretch: @@local
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
-MANALA_HELP += $(call help,update.stretch,Update environment - Jessie)
-update.stretch:
-	@$(MANALA_DOCKER_PULL)
-endif
-
-update.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
-
-MANALA_HELP += \n
-
+	@$(call docker_pull)
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 #########
 # Proxy #
 #########
 
-%@proxy:
-	@$(MANALA_DOCKER_RUN) sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(*)"
+ifeq ($(MANALA_ENV),build)
+@@build: ;
+%@@build: % ;
+else
+@@build:
+	@$(call log_error,Must be run in \"build\" environment)
+	@exit 1
+%@@build:
+	$(call docker_proxy,$(*))
+endif
 
-###########
-# Package #
-###########
+#########
+# Build #
+#########
 
-MANALA_HELP += $(call help_section,Package)
+MANALA_HELP += $(call help_section,Build)
 
-###################
-# Package - Build #
-###################
-
-ifeq ($(MANALA_ENV),local)
+ifndef MANALA_ENV
 
 MANALA_HELP += $(call help,build-all,    Build all packages)
 
-build-all:
-	EXIT=0 ; $(foreach \
-		DEBIAN_DISTRIBUTION,\
-		$(DEBIAN_DISTRIBUTIONS),\
-		$(call log,Build $(DEBIAN_DISTRIBUTION)) \
-			&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
-		|| EXIT=$$? ;\
-	) exit $$EXIT
-
 ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.wheezy, Build package - Wheezy)
-build.wheezy: $(call proxy,build) ;
 endif
-
 ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.jessie, Build package - Jessie)
-build.jessie: $(call proxy,build) ;
 endif
-
 ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
 MANALA_HELP += $(call help,build.stretch,Build package - Stretch)
-build.stretch: $(call proxy,build) ;
 endif
 
-build.%:
-	$(call log_warning,Debian distribution \"$(*)\" is not enabled.)
+endif
 
+build-all: @@local
+	@EXIT=0 ; $(foreach \
+	DEBIAN_DISTRIBUTION,\
+	$(DEBIAN_DISTRIBUTIONS),\
+	$(call log,Build $(DEBIAN_DISTRIBUTION)) \
+	&& $(MAKE) build.$(DEBIAN_DISTRIBUTION) \
+	|| EXIT=$$? ;\
+	) exit $$EXIT
+
+build.wheezy: @@local
+ifneq ($(filter wheezy,$(DEBIAN_DISTRIBUTIONS)),)
+build.wheezy: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.jessie: @@local
+ifneq ($(filter jessie,$(DEBIAN_DISTRIBUTIONS)),)
+build.jessie: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
+endif
+
+build.stretch: @@local
+ifneq ($(filter stretch,$(DEBIAN_DISTRIBUTIONS)),)
+build.stretch: build@@build
+else
+	@$(call log_warning,Debian distribution \"$(DEBIAN_DISTRIBUTION)\" is not enabled.)
 endif
 
 ifeq ($(MANALA_ENV),build)
 
 MANALA_HELP += $(call help,build,Build package)
-build: $(call proxy,build)
 
 endif
 
-build@build: build-clean@build build-package@build build-dist@build
+MANALA_HELP += \n
 
-build-clean@build:
-	rm -Rf $(PACKAGE_BUILD_DIR)/*
+define build_clean
+	@$(call log,Clean)
+	@rm -Rf $(PACKAGE_BUILD_DIR)/*
+	@rm -Rf $(PACKAGE_DIST_DIR)/*~$(DEBIAN_DISTRIBUTION)*.deb
+endef
 
-build-dist@build:
-	$(call log,Dist)
-	for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
+define build_dist
+	@$(call log,Dist)
+	@for DEB in $(PACKAGE_BUILD_DIR)/*.deb; do \
 		basename $$DEB; printf "\n"; \
 		dpkg -I $$DEB; printf "\n"; \
 		dpkg -c $$DEB; printf "\n"; \
 		mv $$DEB $(PACKAGE_DIST_DIR); \
 	done
+endef
+
+build: @@build

--- a/vault/manala/make/Makefile.docker
+++ b/vault/manala/make/Makefile.docker
@@ -1,28 +1,45 @@
-MANALA_DOCKER_RUN = docker run \
-	--rm \
-	--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-	--workdir $(MANALA_DOCKER_DIR) \
-	$(if $(MANALA_INTERACTIVE),--tty --interactive) \
-	$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-	--env USER_ID=$(shell id -u) \
-	--env GROUP_ID=$(shell id -g) \
-	$(if $(MANALA_DOCKER_ENV), \
-		$(foreach \
-			ENV,\
-			$(MANALA_DOCKER_ENV),\
-			--env $(ENV) \
+define docker_run
+	docker run \
+		--rm \
+		$(if $(MANALA_DOCKER_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
+			--workdir $(MANALA_DOCKER_DIR) \
 		) \
-	) \
-	$(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_RUN_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
+		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
+		--env USER_ID=$(shell id -u) \
+		--env GROUP_ID=$(shell id -g) \
+		$(if $(MANALA_DOCKER_ENV), \
+			$(foreach \
+				ENV,\
+				$(MANALA_DOCKER_ENV),\
+				--env $(ENV) \
+			) \
+		) \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_RUN_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		$(1)
+endef
 
-MANALA_DOCKER_PULL = docker pull \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_PULL_OPTIONS) \
-	$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_shell
+	$(call docker_run)
+endef
 
-MANALA_DOCKER_BUILD = docker build \
-  $(MANALA_DOCKER_OPTIONS) \
-	$(MANALA_DOCKER_BUILD_OPTIONS) \
-	--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+define docker_proxy
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+endef
+
+define docker_pull
+	docker pull \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PULL_OPTIONS) \
+		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef
+
+define docker_build
+	docker build \
+		$(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_BUILD_OPTIONS) \
+		--tag $(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+endef

--- a/vault/manala/make/Makefile.environment
+++ b/vault/manala/make/Makefile.environment
@@ -2,24 +2,10 @@
 # Environment #
 ###############
 
-MANALA_ENV ?= local
-
-!@%:
-	@if [ "$(MANALA_ENV)" != "$(*)" ]; then \
-		$(call log_error,Must be run in $(*) environment); \
-		exit 1; \
-	fi
-
-#########
-# Proxy #
-#########
-
-ifeq ($(MANALA_ENV),local)
-define proxy
-	$(1)@proxy
-endef
+ifndef MANALA_ENV
+@@local: ;
 else
-define proxy
-	$(1)@$(MANALA_ENV)
-endef
+@@local:
+	@$(call log_error,Must be run locally)
+	@exit 1
 endif

--- a/vault/manala/make/Makefile.manala
+++ b/vault/manala/make/Makefile.manala
@@ -69,7 +69,7 @@ MANALA_INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 #######
 
 define log
-    printf "\n[$(MANALA_COLOR_COMMENT)$(shell date -u +"%T")$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
+    printf "\n[$(MANALA_COLOR_COMMENT)`date -u +"%T"`$(MANALA_COLOR_RESET)][$(MANALA_COLOR_COMMENT)$(@)$(MANALA_COLOR_RESET)] $(MANALA_COLOR_INFO)$(1)$(MANALA_COLOR_RESET)\n\n"
 endef
 
 # Warning
@@ -86,10 +86,11 @@ endef
 # Confirm #
 ###########
 
-confirm:
-	@printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(if $(CONFIRM_MESSAGE),$(CONFIRM_MESSAGE),Please confirm) (y/N)$(MANALA_COLOR_RESET): "
-	@read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi
-	@printf "\n"
+define confirm
+		printf "\n$(MANALA_COLOR_INFO) ༼ つ ◕_◕ ༽つ $(MANALA_COLOR_WARNING)$(1) (y/N)$(MANALA_COLOR_RESET): "; \
+		read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+		printf "\n"
+endef
 
 ##########
 # Manala #


### PR DESCRIPTION
- [x] Handle global local makefile at root level
- [x] Rename main target "build-package@build" to just... "build"
- [x] Use makefile functions whenever possible (build tasks, docker, ...)
- [x] MANALA_ENV is no more set to "local" by default. If you want to know if you are on local, just check if MANALA_ENV is defined
- [x] Unavailable environment targets now triggered user errors instead of being disabled (ux powa, coucou robinou)
- [x] Use "@@" as separator for environment/proxy handlings
- [x] Remove dist deb files during build cleaning
- [x] Docker: make docker dir optionnal
- [x] Docker new functions "docker_shell" and "docker_proxy"
- [x] Use `date -u +"%T"` instead of $(shell date -u +"%T") for log timestamping to avoid shell called once, and output always the same time across the building tasks
- [x] "Confirm" is now available as a function instead of a target
