### PR TITLE
Use noddebs build option

### DIFF
--- a/keepalived/Makefile
+++ b/keepalived/Makefile
@@ -22,6 +22,8 @@ include manala/make/Makefile
 # Build #
 #########
 
+export DEB_BUILD_OPTIONS = noddebs
+
 build:
 
 	$(call build_clean)

--- a/pam-ssh-agent-auth/Makefile
+++ b/pam-ssh-agent-auth/Makefile
@@ -21,6 +21,8 @@ include manala/make/Makefile
 # Build #
 #########
 
+export DEB_BUILD_OPTIONS = noddebs
+
 build:
 
 	$(call build_clean)

--- a/splitsh-lite/Makefile
+++ b/splitsh-lite/Makefile
@@ -19,6 +19,8 @@ include manala/make/Makefile
 # Build #
 #########
 
+export DEB_BUILD_OPTIONS = noddebs
+
 build: export GOPATH = $(PACKAGE_BUILD_DIR)/go
 build: export PATH  := $(PATH):/usr/local/go/bin
 build:


### PR DESCRIPTION
According to this post, https://lists.debian.org/debian-derivatives/2015/12/msg00007.html, dbgsym packages are built by default from stretch.
This can be disabled using "noddebs" as build option.
Fix https://github.com/manala/debian-packages/issues/6