### PR TITLE
[Splitsh-lite]Temporary libgit2 installation issue workaround

### DIFF
--- a/splitsh-lite/Makefile
+++ b/splitsh-lite/Makefile
@@ -28,7 +28,11 @@ package.checkout:
 	# Git2go
 	sudo apt-get install -y --no-install-recommends \
 		cmake pkg-config libssh2-1-dev libssl-dev libcurl4-openssl-dev
-	go get -v -d github.com/libgit2/git2go
+	# Git clone manually as a temporary workaround to libgit2 install issue
+	# See: https://github.com/libgit2/rugged/issues/711
+	mkdir -p $(PACKAGE_BUILD_DIR)/go/src/github.com/libgit2 \
+		&& cd $(PACKAGE_BUILD_DIR)/go/src/github.com/libgit2 \
+		&& git clone https://github.com/libgit2/git2go.git
 	cd $(GOPATH)/src/github.com/libgit2/git2go \
 		&& git checkout next \
 		&& git submodule update --init \


### PR DESCRIPTION
As seen on https://github.com/libgit2/rugged/issues/711, there is a temporary issue when installing libgit2 via ```go get````

```
# cd /srv/package/build/go/src/github.com/libgit2/git2go; git submodule update --init --recursive
Submodule 'vendor/libgit2' (https://github.com/libgit2/libgit2) registered for path 'vendor/libgit2'
Cloning into 'vendor/libgit2'...
Submodule path 'vendor/libgit2': checked out '15e119375018fba121cf58e02a9f17fe22df0df8'
No submodule mapping found in .gitmodules for path 'tests/resources/rebase-submodule/my-submodule'
Failed to recurse into submodule path 'vendor/libgit2'
package github.com/libgit2/git2go: exit status 1
```

As a workaround, we manually git clone the package.