### PR TITLE
Manala

### DIFF
--- a/.manala/make/Makefile
+++ b/.manala/make/Makefile
@@ -4,12 +4,12 @@
 # Manala #
 ##########
 
-MANALA_DIR = $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.travis \
-	$(MANALA_DIR)/make/Makefile.gitsplit
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.travis \
+	$(MANALA_MAKE_DIR)/Makefile.gitsplit
 
 -include \
 	$(MANALA_CURRENT_DIR)/.env
@@ -29,8 +29,8 @@ PACKAGES_DIFF := $(filter-out .manala,$(sort $(shell git diff --name-only $(TRAV
 
 PART ?= 1/1
 
-PARTITION_PART  := $(call list_first,$(call list_split,/,$(PART)))
-PARTITION_PARTS := $(call list_last,$(call list_split,/,$(PART)))
+PARTITION_PART  := $(call list_split_first,/,$(PART))
+PARTITION_PARTS := $(call list_split_last,/,$(PART))
 
 #########
 # Build #
@@ -102,7 +102,7 @@ SYNC_HELP = \
 	$(call help,sync,Sync packages)
 
 sync:
-	$(call fail_unless,FROM)
+	$(call fail_if_not,$(FROM),FROM is empty or not set)
 	$(call confirm,Please confirm sync from \"$(FROM)\" debian package)
 	for PACKAGE in */; do \
 		echo $$PACKAGE; \

--- a/.manala/make/Makefile.gitsplit
+++ b/.manala/make/Makefile.gitsplit
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 ifeq ($(shell uname -s),Darwin)
 define gitsplit
 	docker run \

--- a/.manala/make/Makefile.manala
+++ b/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/.manala/make/Makefile.manala
+++ b/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/alt-galaxy/.manala/make/Makefile
+++ b/alt-galaxy/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/alt-galaxy/.manala/make/Makefile
+++ b/alt-galaxy/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/alt-galaxy/.manala/make/Makefile.aptly
+++ b/alt-galaxy/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/alt-galaxy/.manala/make/Makefile.docker
+++ b/alt-galaxy/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/alt-galaxy/.manala/make/Makefile.docker
+++ b/alt-galaxy/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/alt-galaxy/.manala/make/Makefile.host
+++ b/alt-galaxy/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/alt-galaxy/.manala/make/Makefile.manala
+++ b/alt-galaxy/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/alt-galaxy/.manala/make/Makefile.manala
+++ b/alt-galaxy/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/ansible/.manala/make/Makefile
+++ b/ansible/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/ansible/.manala/make/Makefile
+++ b/ansible/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/ansible/.manala/make/Makefile.aptly
+++ b/ansible/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/ansible/.manala/make/Makefile.docker
+++ b/ansible/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/ansible/.manala/make/Makefile.docker
+++ b/ansible/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/ansible/.manala/make/Makefile.host
+++ b/ansible/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/ansible/.manala/make/Makefile.manala
+++ b/ansible/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/ansible/.manala/make/Makefile.manala
+++ b/ansible/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/backup-manager/.manala/make/Makefile
+++ b/backup-manager/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/backup-manager/.manala/make/Makefile
+++ b/backup-manager/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/backup-manager/.manala/make/Makefile.aptly
+++ b/backup-manager/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/backup-manager/.manala/make/Makefile.docker
+++ b/backup-manager/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/backup-manager/.manala/make/Makefile.docker
+++ b/backup-manager/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/backup-manager/.manala/make/Makefile.host
+++ b/backup-manager/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/backup-manager/.manala/make/Makefile.manala
+++ b/backup-manager/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/backup-manager/.manala/make/Makefile.manala
+++ b/backup-manager/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/cgroupfs-mount/.manala/make/Makefile
+++ b/cgroupfs-mount/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/cgroupfs-mount/.manala/make/Makefile
+++ b/cgroupfs-mount/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/cgroupfs-mount/.manala/make/Makefile.aptly
+++ b/cgroupfs-mount/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/cgroupfs-mount/.manala/make/Makefile.docker
+++ b/cgroupfs-mount/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/cgroupfs-mount/.manala/make/Makefile.docker
+++ b/cgroupfs-mount/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/cgroupfs-mount/.manala/make/Makefile.host
+++ b/cgroupfs-mount/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/cgroupfs-mount/.manala/make/Makefile.manala
+++ b/cgroupfs-mount/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/cgroupfs-mount/.manala/make/Makefile.manala
+++ b/cgroupfs-mount/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/exa/.manala/make/Makefile
+++ b/exa/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/exa/.manala/make/Makefile
+++ b/exa/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/exa/.manala/make/Makefile.aptly
+++ b/exa/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/exa/.manala/make/Makefile.docker
+++ b/exa/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/exa/.manala/make/Makefile.docker
+++ b/exa/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/exa/.manala/make/Makefile.host
+++ b/exa/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/exa/.manala/make/Makefile.manala
+++ b/exa/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/exa/.manala/make/Makefile.manala
+++ b/exa/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/ffmpeg/.manala/make/Makefile
+++ b/ffmpeg/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/ffmpeg/.manala/make/Makefile
+++ b/ffmpeg/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/ffmpeg/.manala/make/Makefile.aptly
+++ b/ffmpeg/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/ffmpeg/.manala/make/Makefile.docker
+++ b/ffmpeg/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/ffmpeg/.manala/make/Makefile.docker
+++ b/ffmpeg/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/ffmpeg/.manala/make/Makefile.host
+++ b/ffmpeg/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/ffmpeg/.manala/make/Makefile.manala
+++ b/ffmpeg/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/ffmpeg/.manala/make/Makefile.manala
+++ b/ffmpeg/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/gitsplit/.manala/make/Makefile
+++ b/gitsplit/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/gitsplit/.manala/make/Makefile
+++ b/gitsplit/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/gitsplit/.manala/make/Makefile.aptly
+++ b/gitsplit/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/gitsplit/.manala/make/Makefile.docker
+++ b/gitsplit/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/gitsplit/.manala/make/Makefile.docker
+++ b/gitsplit/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/gitsplit/.manala/make/Makefile.host
+++ b/gitsplit/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/gitsplit/.manala/make/Makefile.manala
+++ b/gitsplit/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/gitsplit/.manala/make/Makefile.manala
+++ b/gitsplit/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/httpie/.manala/make/Makefile
+++ b/httpie/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/httpie/.manala/make/Makefile
+++ b/httpie/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/httpie/.manala/make/Makefile.aptly
+++ b/httpie/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/httpie/.manala/make/Makefile.docker
+++ b/httpie/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/httpie/.manala/make/Makefile.docker
+++ b/httpie/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/httpie/.manala/make/Makefile.host
+++ b/httpie/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/httpie/.manala/make/Makefile.manala
+++ b/httpie/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/httpie/.manala/make/Makefile.manala
+++ b/httpie/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/hugo/.manala/make/Makefile
+++ b/hugo/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/hugo/.manala/make/Makefile
+++ b/hugo/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/hugo/.manala/make/Makefile.aptly
+++ b/hugo/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/hugo/.manala/make/Makefile.docker
+++ b/hugo/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/hugo/.manala/make/Makefile.docker
+++ b/hugo/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/hugo/.manala/make/Makefile.host
+++ b/hugo/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/hugo/.manala/make/Makefile.manala
+++ b/hugo/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/hugo/.manala/make/Makefile.manala
+++ b/hugo/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/jinja2/.manala/make/Makefile
+++ b/jinja2/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/jinja2/.manala/make/Makefile
+++ b/jinja2/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/jinja2/.manala/make/Makefile.aptly
+++ b/jinja2/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/jinja2/.manala/make/Makefile.docker
+++ b/jinja2/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/jinja2/.manala/make/Makefile.docker
+++ b/jinja2/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/jinja2/.manala/make/Makefile.host
+++ b/jinja2/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/jinja2/.manala/make/Makefile.manala
+++ b/jinja2/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/jinja2/.manala/make/Makefile.manala
+++ b/jinja2/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/keepalived/.manala/make/Makefile
+++ b/keepalived/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/keepalived/.manala/make/Makefile
+++ b/keepalived/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/keepalived/.manala/make/Makefile.aptly
+++ b/keepalived/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/keepalived/.manala/make/Makefile.docker
+++ b/keepalived/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/keepalived/.manala/make/Makefile.docker
+++ b/keepalived/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/keepalived/.manala/make/Makefile.host
+++ b/keepalived/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/keepalived/.manala/make/Makefile.manala
+++ b/keepalived/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/keepalived/.manala/make/Makefile.manala
+++ b/keepalived/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/mailhog/.manala/make/Makefile
+++ b/mailhog/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/mailhog/.manala/make/Makefile
+++ b/mailhog/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/mailhog/.manala/make/Makefile.aptly
+++ b/mailhog/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/mailhog/.manala/make/Makefile.docker
+++ b/mailhog/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/mailhog/.manala/make/Makefile.docker
+++ b/mailhog/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/mailhog/.manala/make/Makefile.host
+++ b/mailhog/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/mailhog/.manala/make/Makefile.manala
+++ b/mailhog/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/mailhog/.manala/make/Makefile.manala
+++ b/mailhog/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/mongo-express/.manala/make/Makefile
+++ b/mongo-express/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/mongo-express/.manala/make/Makefile
+++ b/mongo-express/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/mongo-express/.manala/make/Makefile.aptly
+++ b/mongo-express/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/mongo-express/.manala/make/Makefile.docker
+++ b/mongo-express/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/mongo-express/.manala/make/Makefile.docker
+++ b/mongo-express/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/mongo-express/.manala/make/Makefile.host
+++ b/mongo-express/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/mongo-express/.manala/make/Makefile.manala
+++ b/mongo-express/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/mongo-express/.manala/make/Makefile.manala
+++ b/mongo-express/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/ngrok/.manala/make/Makefile
+++ b/ngrok/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/ngrok/.manala/make/Makefile
+++ b/ngrok/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/ngrok/.manala/make/Makefile.aptly
+++ b/ngrok/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/ngrok/.manala/make/Makefile.docker
+++ b/ngrok/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/ngrok/.manala/make/Makefile.docker
+++ b/ngrok/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/ngrok/.manala/make/Makefile.host
+++ b/ngrok/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/ngrok/.manala/make/Makefile.manala
+++ b/ngrok/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/ngrok/.manala/make/Makefile.manala
+++ b/ngrok/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/oauth2-proxy/.manala/make/Makefile
+++ b/oauth2-proxy/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/oauth2-proxy/.manala/make/Makefile
+++ b/oauth2-proxy/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/oauth2-proxy/.manala/make/Makefile.aptly
+++ b/oauth2-proxy/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/oauth2-proxy/.manala/make/Makefile.docker
+++ b/oauth2-proxy/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/oauth2-proxy/.manala/make/Makefile.docker
+++ b/oauth2-proxy/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/oauth2-proxy/.manala/make/Makefile.host
+++ b/oauth2-proxy/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/oauth2-proxy/.manala/make/Makefile.manala
+++ b/oauth2-proxy/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/oauth2-proxy/.manala/make/Makefile.manala
+++ b/oauth2-proxy/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/opcache-dashboard/.manala/make/Makefile
+++ b/opcache-dashboard/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/opcache-dashboard/.manala/make/Makefile
+++ b/opcache-dashboard/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/opcache-dashboard/.manala/make/Makefile.aptly
+++ b/opcache-dashboard/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/opcache-dashboard/.manala/make/Makefile.docker
+++ b/opcache-dashboard/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/opcache-dashboard/.manala/make/Makefile.docker
+++ b/opcache-dashboard/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/opcache-dashboard/.manala/make/Makefile.host
+++ b/opcache-dashboard/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/opcache-dashboard/.manala/make/Makefile.manala
+++ b/opcache-dashboard/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/opcache-dashboard/.manala/make/Makefile.manala
+++ b/opcache-dashboard/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/pam-ssh-agent-auth/.manala/make/Makefile
+++ b/pam-ssh-agent-auth/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/pam-ssh-agent-auth/.manala/make/Makefile
+++ b/pam-ssh-agent-auth/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/pam-ssh-agent-auth/.manala/make/Makefile.aptly
+++ b/pam-ssh-agent-auth/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/pam-ssh-agent-auth/.manala/make/Makefile.docker
+++ b/pam-ssh-agent-auth/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/pam-ssh-agent-auth/.manala/make/Makefile.docker
+++ b/pam-ssh-agent-auth/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/pam-ssh-agent-auth/.manala/make/Makefile.host
+++ b/pam-ssh-agent-auth/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/pam-ssh-agent-auth/.manala/make/Makefile.manala
+++ b/pam-ssh-agent-auth/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/pam-ssh-agent-auth/.manala/make/Makefile.manala
+++ b/pam-ssh-agent-auth/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/phantomjs/.manala/make/Makefile
+++ b/phantomjs/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/phantomjs/.manala/make/Makefile
+++ b/phantomjs/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/phantomjs/.manala/make/Makefile.aptly
+++ b/phantomjs/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/phantomjs/.manala/make/Makefile.docker
+++ b/phantomjs/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/phantomjs/.manala/make/Makefile.docker
+++ b/phantomjs/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/phantomjs/.manala/make/Makefile.host
+++ b/phantomjs/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/phantomjs/.manala/make/Makefile.manala
+++ b/phantomjs/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/phantomjs/.manala/make/Makefile.manala
+++ b/phantomjs/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/phpmyadmin/.manala/make/Makefile
+++ b/phpmyadmin/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/phpmyadmin/.manala/make/Makefile
+++ b/phpmyadmin/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/phpmyadmin/.manala/make/Makefile.aptly
+++ b/phpmyadmin/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/phpmyadmin/.manala/make/Makefile.docker
+++ b/phpmyadmin/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/phpmyadmin/.manala/make/Makefile.docker
+++ b/phpmyadmin/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/phpmyadmin/.manala/make/Makefile.host
+++ b/phpmyadmin/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/phpmyadmin/.manala/make/Makefile.manala
+++ b/phpmyadmin/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/phpmyadmin/.manala/make/Makefile.manala
+++ b/phpmyadmin/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/phppgadmin/.manala/make/Makefile
+++ b/phppgadmin/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/phppgadmin/.manala/make/Makefile
+++ b/phppgadmin/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/phppgadmin/.manala/make/Makefile.aptly
+++ b/phppgadmin/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/phppgadmin/.manala/make/Makefile.docker
+++ b/phppgadmin/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/phppgadmin/.manala/make/Makefile.docker
+++ b/phppgadmin/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/phppgadmin/.manala/make/Makefile.host
+++ b/phppgadmin/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/phppgadmin/.manala/make/Makefile.manala
+++ b/phppgadmin/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/phppgadmin/.manala/make/Makefile.manala
+++ b/phppgadmin/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/phpredisadmin/.manala/make/Makefile
+++ b/phpredisadmin/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/phpredisadmin/.manala/make/Makefile
+++ b/phpredisadmin/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/phpredisadmin/.manala/make/Makefile.aptly
+++ b/phpredisadmin/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/phpredisadmin/.manala/make/Makefile.docker
+++ b/phpredisadmin/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/phpredisadmin/.manala/make/Makefile.docker
+++ b/phpredisadmin/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/phpredisadmin/.manala/make/Makefile.host
+++ b/phpredisadmin/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/phpredisadmin/.manala/make/Makefile.manala
+++ b/phpredisadmin/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/phpredisadmin/.manala/make/Makefile.manala
+++ b/phpredisadmin/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/python-pathlib2/.manala/make/Makefile
+++ b/python-pathlib2/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/python-pathlib2/.manala/make/Makefile
+++ b/python-pathlib2/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/python-pathlib2/.manala/make/Makefile.aptly
+++ b/python-pathlib2/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/python-pathlib2/.manala/make/Makefile.docker
+++ b/python-pathlib2/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/python-pathlib2/.manala/make/Makefile.docker
+++ b/python-pathlib2/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/python-pathlib2/.manala/make/Makefile.host
+++ b/python-pathlib2/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/python-pathlib2/.manala/make/Makefile.manala
+++ b/python-pathlib2/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/python-pathlib2/.manala/make/Makefile.manala
+++ b/python-pathlib2/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/rtail/.manala/make/Makefile
+++ b/rtail/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/rtail/.manala/make/Makefile
+++ b/rtail/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/rtail/.manala/make/Makefile.aptly
+++ b/rtail/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/rtail/.manala/make/Makefile.docker
+++ b/rtail/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/rtail/.manala/make/Makefile.docker
+++ b/rtail/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/rtail/.manala/make/Makefile.host
+++ b/rtail/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/rtail/.manala/make/Makefile.manala
+++ b/rtail/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/rtail/.manala/make/Makefile.manala
+++ b/rtail/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/splitsh-lite/.manala/make/Makefile
+++ b/splitsh-lite/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/splitsh-lite/.manala/make/Makefile
+++ b/splitsh-lite/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/splitsh-lite/.manala/make/Makefile.aptly
+++ b/splitsh-lite/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/splitsh-lite/.manala/make/Makefile.docker
+++ b/splitsh-lite/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/splitsh-lite/.manala/make/Makefile.docker
+++ b/splitsh-lite/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/splitsh-lite/.manala/make/Makefile.host
+++ b/splitsh-lite/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/splitsh-lite/.manala/make/Makefile.manala
+++ b/splitsh-lite/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/splitsh-lite/.manala/make/Makefile.manala
+++ b/splitsh-lite/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/supervisor/.manala/make/Makefile
+++ b/supervisor/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/supervisor/.manala/make/Makefile
+++ b/supervisor/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/supervisor/.manala/make/Makefile.aptly
+++ b/supervisor/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/supervisor/.manala/make/Makefile.docker
+++ b/supervisor/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/supervisor/.manala/make/Makefile.docker
+++ b/supervisor/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/supervisor/.manala/make/Makefile.host
+++ b/supervisor/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/supervisor/.manala/make/Makefile.manala
+++ b/supervisor/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/supervisor/.manala/make/Makefile.manala
+++ b/supervisor/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/thefuck/.manala/make/Makefile
+++ b/thefuck/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/thefuck/.manala/make/Makefile
+++ b/thefuck/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/thefuck/.manala/make/Makefile.aptly
+++ b/thefuck/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/thefuck/.manala/make/Makefile.docker
+++ b/thefuck/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/thefuck/.manala/make/Makefile.docker
+++ b/thefuck/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/thefuck/.manala/make/Makefile.host
+++ b/thefuck/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/thefuck/.manala/make/Makefile.manala
+++ b/thefuck/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/thefuck/.manala/make/Makefile.manala
+++ b/thefuck/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch

--- a/vault/.manala/make/Makefile
+++ b/vault/.manala/make/Makefile
@@ -50,7 +50,7 @@ endef
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
-MANALA_DOCKER_DIR       = /srv/package
+MANALA_DOCKER_MOUNT_DIR = /srv/package
 MANALA_DOCKER_HOST      = $(PACKAGE).$(DISTRIBUTION).build
 MANALA_DOCKER_VOLUMES   = \
 	$(if $(CACHE_DIR), \

--- a/vault/.manala/make/Makefile
+++ b/vault/.manala/make/Makefile
@@ -4,13 +4,13 @@
 # Manala #
 ##########
 
-MANALA_DIR := $(abspath $(patsubst %/make/Makefile,%,$(firstword $(filter %.manala/make/Makefile,$(MAKEFILE_LIST)))))
+MANALA_MAKE_DIR := $(abspath $(patsubst %/Makefile,%,$(lastword $(MAKEFILE_LIST))))
 
 include \
-	$(MANALA_DIR)/make/Makefile.manala \
-	$(MANALA_DIR)/make/Makefile.docker \
-	$(MANALA_DIR)/make/Makefile.host \
-	$(MANALA_DIR)/make/Makefile.aptly
+	$(MANALA_MAKE_DIR)/Makefile.manala \
+	$(MANALA_MAKE_DIR)/Makefile.docker \
+	$(MANALA_MAKE_DIR)/Makefile.host \
+	$(MANALA_MAKE_DIR)/Makefile.aptly
 
 -include \
 	$(MANALA_CURRENT_DIR)/../.env \
@@ -46,7 +46,7 @@ endef
 # Docker #
 ##########
 
-# Note: "DEB_BUILD_OPTIONS=noddebs" to get rid of dbgsym packages
+# Note: "DEB_BUILD_OPTIONS=noautodbgsym" to get rid of dbgsym packages
 
 MANALA_DOCKER_IMAGE     = manala/build-debian
 MANALA_DOCKER_IMAGE_TAG = $(if $(DOCKER_TAG),$(DOCKER_TAG)-)$(DISTRIBUTION)
@@ -58,12 +58,14 @@ MANALA_DOCKER_VOLUMES   = \
 		$(CACHE_DIR)/$(DISTRIBUTION)/apt/lists:/var/lib/apt/lists \
 	)
 MANALA_DOCKER_ENV       = \
+	USER_ID=$(MANALA_USER_ID) \
+	GROUP_ID=$(MANALA_GROUP_ID) \
 	MANALA_HOST=build \
 	MANALA_VERBOSE=$(MANALA_VERBOSE) \
 	DISTRIBUTION=$(DISTRIBUTION) \
 	DEBFULLNAME=$(MANALA_CONTACT_NAME) \
 	DEBEMAIL=$(MANALA_CONTACT_MAIL) \
-	DEB_BUILD_OPTIONS=noddebs
+	DEB_BUILD_OPTIONS=noautodbgsym
 
 ######
 # Sh #
@@ -74,8 +76,8 @@ MANALA_HELP += $(call if_host,local,$(SH_HELP)\n)
 SH_HELP = \
 	$(call help_section,Build host shell)
 
-sh: .host_restrict(local)
-	$(call fail_unless,DISTRIBUTION)
+sh: .fail_if_host_not(local)
+	$(call fail_if_not,$(DISTRIBUTION),DISTRIBUTION is empty or not set)
 	$(call if_in,$(DISTRIBUTION),$(PACKAGE_DISTRIBUTIONS), \
 		$(call docker_shell), \
 		$(call log_warning,Shell on \"$(DISTRIBUTION)\" is not supported) \
@@ -103,7 +105,7 @@ UPDATE_HELP = \
 	$(call help_section,Build host update) \
 	$(call help,update,        Update build hosts across distributions)
 
-update: .host_restrict(local)
+update: .fail_if_host_not(local)
 	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Update \"$$(DISTRIBUTION)\") ; \
@@ -135,7 +137,7 @@ SYSTEM_HELP = \
 	$(call help,system.update,Update system)
 
 system.update: DEBIAN_FRONTEND = noninteractive
-system.update: .host_restrict(build)
+system.update: .fail_if_host_not(build)
 	$(call log,Update)
 	sudo apt-get $(call verbose,-qq,-qq, ) update
 	sudo apt-get $(call verbose,-qq,-q -V,-V) -y dist-upgrade
@@ -154,8 +156,8 @@ BUILD_HELP_BUILD = $(BUILD_HELP) \
 
 build: .host_switch(build)
 
-build@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+build@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Build \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,build@build), \
@@ -163,7 +165,7 @@ build@local: .host_restrict(local)
 		) \
 	)
 
-build@build: .host_restrict(build) \
+build@build: .fail_if_host_not(build) \
 	system.update \
 	package.clean \
 	package.checkout \
@@ -199,8 +201,8 @@ LINT_HELP_BUILD = $(LINT_HELP) \
 
 lint: .host_switch(lint)
 
-lint@local: .host_restrict(local)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+lint@local: .fail_if_host_not(local)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call log,Lint \"$$(PACKAGE)\" on \"$$(DISTRIBUTION)\") ; \
 				$$(call docker_make,lint@build), \
@@ -208,7 +210,7 @@ lint@local: .host_restrict(local)
 		) \
 	)
 
-lint@build: .host_restrict(build)
+lint@build: .fail_if_host_not(build)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_DIST_DIR)/*.deb), \
 		$(call verbose, ,basename $(PACKAGE) ; echo ; ) \
 		lintian $(call verbose, , , ,--info) $(PACKAGE) || true ; \
@@ -235,22 +237,22 @@ MANALA_HELP += $(call if_host,build,$(PACKAGE_HELP))
 PACKAGE_HELP = $(call help_section,Package)
 
 PACKAGE_HELP += $(call help,package.clean,       Package - Clean)
-package.clean: .host_restrict(build)
+package.clean: .fail_if_host_not(build)
 	$(call log,Clean)
 	rm $(call verbose, , ,--verbose) --recursive --force \
 		$(PACKAGE_BUILD_DIR)/* $(PACKAGE_DIST_DIR)/*.deb
 
 PACKAGE_HELP += $(call help,package.checkout,    Package - Checkout)
-package.checkout: .host_restrict(build)
+package.checkout: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.prepare,     Package - Prepare)
-package.prepare: .host_restrict(build)
+package.prepare: .fail_if_host_not(build)
 
 # Create a patch (in build directory):
 #   $ diff -Naur [file] [file].patch > ../patches/[distribution]/XXX.[name].patch
 PACKAGE_HELP += $(call help,package.patch,       Package - Patch)
 package.patch: PATCHES = $(sort $(wildcard $(PACKAGE_DIR)/patches/$(DISTRIBUTION)/*.patch))
-package.patch: .host_restrict(build)
+package.patch: .fail_if_host_not(build)
 	$(call log,Patch)
 	$(foreach PATCH,$(PATCHES), \
 		cd $(PACKAGE_BUILD_DIR) && \
@@ -258,7 +260,7 @@ package.patch: .host_restrict(build)
 	)
 
 PACKAGE_HELP += $(call help,package.dependencies,Package - Dependencies)
-package.dependencies: .host_restrict(build)
+package.dependencies: .fail_if_host_not(build)
 	$(call log,Dependencies)
 	cd $(PACKAGE_BUILD_DIR)/$(PACKAGE) \
 		&& mk-build-deps \
@@ -267,10 +269,10 @@ package.dependencies: .host_restrict(build)
 			debian/control $(call verbose,>/dev/null 2>&1,>/dev/null, )
 
 PACKAGE_HELP += $(call help,package.build,       Package - Build)
-package.build: .host_restrict(build)
+package.build: .fail_if_host_not(build)
 
 PACKAGE_HELP += $(call help,package.dist,        Package - Dist)
-package.dist: .host_restrict(build)
+package.dist: .fail_if_host_not(build)
 	$(call log,Dist)
 	mkdir $(call verbose, , ,--verbose) --parents $(PACKAGE_DIST_DIR)
 	$(foreach PACKAGE,$(wildcard $(PACKAGE_BUILD_DIR)/*.deb), \
@@ -297,10 +299,10 @@ DEPLOY_HELP = \
 	$(call help_section,Deploy) \
 	$(call help,deploy,        Deploy packages to repository across distributions)
 
-deploy: .host_restrict(local)
-	$(call fail_unless,DEPLOY_HOST)
-	$(call fail_unless,DEPLOY_USER)
-	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(call uniq,$(DISTRIBUTIONS)),$(PACKAGE_DISTRIBUTIONS)), \
+deploy: .fail_if_host_not(local)
+	$(call fail_if_not,$(DEPLOY_HOST),DEPLOY_HOST is empty or not set)
+	$(call fail_if_not,$(DEPLOY_USER),DEPLOY_USER is empty or not set)
+	$(call list_loop,DISTRIBUTION,$(if $(DISTRIBUTIONS),$(DISTRIBUTIONS),$(PACKAGE_DISTRIBUTIONS)), \
 		$$(call log,Distribution \"$$(DISTRIBUTION)\") ; \
 		$$(call if_in,$$(DISTRIBUTION),$$(PACKAGE_DISTRIBUTIONS), \
 			$$(call confirm,Please confirm deploy on \"$$(DISTRIBUTION)\" distribution) ; \

--- a/vault/.manala/make/Makefile.aptly
+++ b/vault/.manala/make/Makefile.aptly
@@ -7,6 +7,10 @@
 # MANALA_APTLY_PACKAGES:   Aptly packages
 # MANALA_APTLY_REPOSITORY: Aptly repository
 
+#############
+# Functions #
+#############
+
 define aptly_deploy
   scp $(MANALA_APTLY_PACKAGES) $(MANALA_APTLY_HOST):/tmp && \
   ssh $(MANALA_APTLY_HOST) -- sudo -u $(MANALA_APTLY_USER) aptly repo add $(MANALA_APTLY_REPOSITORY) /tmp/$(notdir $(MANALA_APTLY_PACKAGES)) && \

--- a/vault/.manala/make/Makefile.docker
+++ b/vault/.manala/make/Makefile.docker
@@ -1,3 +1,7 @@
+#############
+# Functions #
+#############
+
 define docker_run
 	docker run \
 		--rm \
@@ -7,8 +11,6 @@ define docker_run
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
-		--env USER_ID=$(shell id -u) \
-		--env GROUP_ID=$(shell id -g) \
 		$(if $(MANALA_DOCKER_VOLUMES), \
 			$(foreach \
 				VOLUME,\
@@ -19,8 +21,8 @@ define docker_run
 		$(if $(MANALA_DOCKER_ENV), \
 			$(foreach \
 				ENV,\
-				 $(call escape,$(MANALA_DOCKER_ENV)),\
-				--env $(call unescape,$(ENV)) \
+				 $(call encode_spaces,$(MANALA_DOCKER_ENV)),\
+				--env $(call decode_spaces,$(ENV)) \
 			) \
 		) \
 		$(MANALA_DOCKER_OPTIONS) \

--- a/vault/.manala/make/Makefile.docker
+++ b/vault/.manala/make/Makefile.docker
@@ -5,9 +5,9 @@
 define docker_run
 	docker run \
 		--rm \
-		$(if $(MANALA_DOCKER_DIR), \
-			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_DIR) \
-			--workdir $(MANALA_DOCKER_DIR) \
+		$(if $(MANALA_DOCKER_MOUNT_DIR), \
+			--volume $(MANALA_CURRENT_DIR):$(MANALA_DOCKER_MOUNT_DIR) \
+			--workdir $(MANALA_DOCKER_MOUNT_DIR) \
 		) \
 		$(if $(MANALA_INTERACTIVE),--tty --interactive) \
 		$(if $(MANALA_DOCKER_HOST),--hostname $(MANALA_DOCKER_HOST)) \
@@ -36,14 +36,27 @@ define docker_shell
 endef
 
 define docker_make
-	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_DIR) $(1)")
+	$(call docker_run,sh -c "make --silent --directory=$(MANALA_DOCKER_MOUNT_DIR) $(1)")
 endef
 
 define docker_pull
 	docker pull \
 	  $(MANALA_DOCKER_OPTIONS) \
 		$(MANALA_DOCKER_PULL_OPTIONS) \
-		$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest)
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
+endef
+
+define docker_push
+	docker push \
+	  $(MANALA_DOCKER_OPTIONS) \
+		$(MANALA_DOCKER_PUSH_OPTIONS) \
+		$(if $(1), \
+			$(1), \
+			$(MANALA_DOCKER_IMAGE):$(if $(MANALA_DOCKER_IMAGE_TAG),$(MANALA_DOCKER_IMAGE_TAG),latest) \
+		)
 endef
 
 define docker_build

--- a/vault/.manala/make/Makefile.host
+++ b/vault/.manala/make/Makefile.host
@@ -5,11 +5,15 @@
 MANALA_HOST ?= local
 
 # Usage:
-#   target: .host_restrict(local)
+#   target: .fail_if_host_not(local)
 #   	# Do something on local host...
 
-.host_restrict(%):
-	$(call if_eq,$(*),$(MANALA_HOST),,$(call message_error,Must be run on \"$(*)\" host); exit 1)
+.fail_if_host_not(%):
+	$(call fail_if_host_not,$(*))
+
+define fail_if_host_not
+$(call if_eq,$(1),$(MANALA_HOST),,$(call message_error,Must be run on \"$(1)\" host); exit 1)
+endef
 
 # Usage:
 #   $(call if_host,local,Yes,No) = Yes

--- a/vault/.manala/make/Makefile.manala
+++ b/vault/.manala/make/Makefile.manala
@@ -5,24 +5,27 @@
 # GNU Make Standard Library #
 #############################
 
-include $(MANALA_DIR)/make/gmsl/gmsl
+include $(MANALA_MAKE_DIR)/gmsl/gmsl
 
-#############
-# Variables #
-#############
+###############
+# Directories #
+###############
 
-# MANALA_CURRENT_DIR [String]  Current directory
-# MANALA_DIR         [String]  Manala base directory
-# MANALA_HELP        [String]  Help content
-# MANALA_INTERACTIVE [Empty]|1 Run in interactive mode
+MANALA_DIR         := $(patsubst %/make,%,$(MANALA_MAKE_DIR))
+MANALA_CURRENT_DIR := $(CURDIR)
 
+###########
+# Contact #
+###########
+
+MANALA_CONTACT       = $(MANALA_CONTACT_NAME) <$(MANALA_CONTACT_MAIL)>
 MANALA_CONTACT_NAME := Manala
 MANALA_CONTACT_MAIL := contact@manala.io
 
-# Current dir
-MANALA_CURRENT_DIR := $(CURDIR)
+##########
+# Colors #
+##########
 
-# Colors
 MANALA_COLOR_RESET   := \033[0m
 MANALA_COLOR_ERROR   := \033[31m
 MANALA_COLOR_INFO    := \033[32m
@@ -61,6 +64,13 @@ ifneq ($(MANALA_CURRENT_DIR),$(MANALA_DIR))
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 endif
 	@printf "\n\n"
+
+################
+# User / Group #
+################
+
+MANALA_USER_ID  := $(shell id -u)
+MANALA_GROUP_ID := $(shell id -g)
 
 ###############
 # Interactive #
@@ -162,17 +172,25 @@ space +=
 $(space) :=
 $(space) +=
 
-# A lot of makefile functions, such as "foreach", don't support space escaping operator "\ ".
-# Using escape/unescape, one can simulate such support.
-#
 # Usage:
-#   $(foreach ITEM,$(call escape,foo bar\ baz),echo $(call unescape,$(ITEM))) = foo\nbar baz\n
+#   $(call escape_spaces,foo bar)    = foo\ bar
+#   $(call unescape_spaces,foo\ bar) = foo bar
+#   $(call encode_spaces,foo\ bar)   = foo␣bar
+#   $(call decode_spaces,foo␣bar)    = foo bar
 
-define escape
+define escape_spaces
+$(subst $( ),\ ,$(1))
+endef
+
+define unescape_spaces
+$(subst \ ,$( ),$(1))
+endef
+
+define encode_spaces
 $(subst \ ,␣,$(1))
 endef
 
-define unescape
+define decode_spaces
 $(subst ␣, ,$(1))
 endef
 
@@ -180,8 +198,12 @@ endef
 # Fail #
 ########
 
-define fail_unless
-	$(if $($(1)),,$(call message_error,\"$(1)\" is empty or not set); exit 1)
+define fail_if_not
+	$(if $(1),,$(call message_error,$(2)); exit 1)
+endef
+
+define fail_if_not_in
+	$(call if_in,$(1),$(2),,$(call message_error,$(3)); exit 1)
 endef
 
 ###########
@@ -233,6 +255,7 @@ endef
 # List #
 ########
 
+# Returns the list with duplicate elements removed without reordering
 # Usage:
 #   $(call list_uniq,foo bar bar baz) = foo bar
 
@@ -240,6 +263,7 @@ define list_uniq
 $(call uniq,$(1))
 endef
 
+# Splits a string into a list separated by spaces at the split character in the first argument
 # Usage:
 #   $(call list_split,:,foo:bar) = foo bar
 
@@ -248,17 +272,49 @@ $(call split,$(1),$(2))
 endef
 
 # Usage:
+#   $(call list_split_first,:,foo:bar) = foo
+
+define list_split_first
+$(call list_first,$(call list_split,$(1),$(2)))
+endef
+
+# Usage:
+#   $(call list_split_last,:,foo:bar) = bar
+
+define list_split_last
+$(call list_last,$(call list_split,$(1),$(2)))
+endef
+
+# Returns the first element of a list
+# Usage:
 #   $(call list_first,foo bar) = foo
 
 define list_first
 $(call first,$(1))
 endef
 
+# Returns the last element of a list
 # Usage:
 #   $(call list_last,foo bar) = bar
 
 define list_last
 $(call last,$(1))
+endef
+
+# Returns the list with the first element removed
+# Usage:
+#   $(call list_rest,foo bar baz) = bar baz
+
+define list_rest
+$(call rest,$(1))
+endef
+
+# Returns the list with the last element removed
+# Usage:
+#   $(call list_chop,foo bar baz) = foo bar
+
+define list_chop
+$(call chop,$(1))
 endef
 
 # Usage:
@@ -297,6 +353,32 @@ endef
 define list_partition_size
 $(call if_eq,$(1),$(2),$(3),$(call subtract,$(call if_gte,$(3),$(2),$(call divide,$(3),$(2)),1,),1))
 endef
+
+##########
+# Semver #
+##########
+
+# Usage:
+#   $(call semver_major,3.2.1) = 3
+
+define semver_major
+$(call list_first,$(call list_split,.,$(1)))
+endef
+
+# Usage:
+#   $(call semver_minor,3.2.1) = 2
+
+define semver_minor
+$(call list_first,$(call list_rest,$(call list_split,.,$(1))))
+endef
+
+# Usage:
+#   $(call semver_patch,3.2.1) = 1
+
+define semver_patch
+$(call list_last,$(call list_split,.,$(1)))
+endef
+
 
 ########
 # Rand #

--- a/vault/.manala/make/Makefile.manala
+++ b/vault/.manala/make/Makefile.manala
@@ -373,6 +373,13 @@ $(call list_first,$(call list_rest,$(call list_split,.,$(1))))
 endef
 
 # Usage:
+#   $(call semver_major_minor,3.2.1) = 3.2
+
+define semver_major_minor
+$(call semver_major,$(1)).$(call semver_minor,$(1))
+endef
+
+# Usage:
 #   $(call semver_patch,3.2.1) = 1
 
 define semver_patch


### PR DESCRIPTION
- Template makefiles must define `MANALA_MAKE_DIR`instead of `MANALA_DIR`
- **Makefile.docker**: Rename `MANALA_DOCKER_DIR` into `MANALA_DOCKER_MOUNT_DIR` to avoid conflicts
- **Makefile.manala**: Introduce `semver_major_minor`function
- **Makefile.docker**: Let `docker_pull`function accepts a custom image parameter
- **Makefile.docker**: Introduce `docker_push`function