### PR TITLE
[Jinja2] Remove stretch support

### DIFF
--- a/jinja2/Makefile
+++ b/jinja2/Makefile
@@ -15,7 +15,7 @@ PACKAGE_VERSION                      = 2.8
 PACKAGE_REVISION                     = 1
 PACKAGE_REVISION_MANALA              = 1
 PACKAGE_REVISION_MANALA_DISTRIBUTION = 1
-PACKAGE_DISTRIBUTIONS                = wheezy jessie stretch
+PACKAGE_DISTRIBUTIONS                = wheezy jessie
 
 package.checkout:
 	$(call log,Checkout)


### PR DESCRIPTION
We no longer need to backport jinja on stretch, as upstream version (2.8-1) is recent enough.